### PR TITLE
mongoDB 결과 데이터 추가 및 변경, onlinedl re-run 버그픽스

### DIFF
--- a/inference-dl/inferencedl/inferencedl.py
+++ b/inference-dl/inferencedl/inferencedl.py
@@ -55,6 +55,7 @@ class InferenceDL:
 
             if _sum > 0.0:
                 self.model = tmp_model
+                post = {}
                 post['updated_at_inferencedl'] = datetime.datetime.now()
                 self.collection.insert_one(post)
 

--- a/inference-dl/inferencedl/inferencedl.py
+++ b/inference-dl/inferencedl/inferencedl.py
@@ -32,8 +32,6 @@ class InferenceDL:
         self.collection.remove({})
         self.model_name = model_name
 
-        self.transition_decision = 0.1
-
     # Below consume-function implement feedforward and send results to database (mongodb)
     def consume(self, data, id):
         result = self.model.predict(data.reshape(self.batch_input_shape), batch_size=data.shape[0])
@@ -55,7 +53,7 @@ class InferenceDL:
             for w1, w2 in zip(tmp_model.get_weights(), self.model.get_weights()):
                 _sum += np.sum((w1 - w2) ** 2)
 
-            if _sum > self.transition_decision:
+            if _sum > 0.0:
                 self.model = tmp_model
                 post['updated_at_inferencedl'] = datetime.datetime.now()
                 self.collection.insert_one(post)

--- a/inference-dl/inferencedl/inferencedl.py
+++ b/inference-dl/inferencedl/inferencedl.py
@@ -1,4 +1,4 @@
-import os, time
+import os, time, datetime
 import tensorflow as tf
 from onlinedl.utils import ModelManager
 from pymongo import MongoClient
@@ -45,7 +45,7 @@ class InferenceDL:
             post['amiid'] = i.item()
             post['pred'] = result[np.where(id.reshape((id.shape[0],))==i)].tolist() # shape is (batch,)
             post['true'] = data[np.where(id.reshape((id.shape[0],))==i)].tolist() # shape is (batch,)
-            post['timestamp'] = time.time() # time.time() is global UTC value
+            post['timestamp'] = datetime.datetime.now()
             self.collection.insert_one(post)
 
         if self.model_manager.download_model(self.save_path):
@@ -57,6 +57,6 @@ class InferenceDL:
 
             if _sum > self.transition_decision:
                 self.model = tmp_model
-                post['updated_at'] = time.time()
+                post['updated_at_inferencedl'] = datetime.datetime.now()
                 self.collection.insert_one(post)
 

--- a/online-dl/online_trainer.py
+++ b/online-dl/online_trainer.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
             x_batch, y_batch, id_batch, scailed_epoch = strstub.batch_train_generator(training_error)
             training_error = trainer.consume(x_batch, y_batch, id_batch, scailed_epoch)
             if save_weights:
-                if trainer._loss < base_loss * 0.1:
+                if trainer._loss < base_loss * 0.9:
                     base_loss = trainer._loss
                     trainer.save()
 
@@ -87,10 +87,9 @@ if __name__ == '__main__':
         while True:
             _, x_batch, y_batch, id_batch = next(stream_generator)
             trainer.consume(x_batch, y_batch, id_batch)
-            #TODO: save_weights or model itself to model_repository (CH)
 
             if save_weights:
-                if trainer._loss < base_loss*0.1:
+                if trainer._loss < base_loss*0.99:
                     base_loss = trainer._loss
                     trainer.save()
 

--- a/online-dl/onlinedl/onlinedl.py
+++ b/online-dl/onlinedl/onlinedl.py
@@ -1,4 +1,4 @@
-import os, time
+import os, time, datetime
 import tensorflow as tf
 import tensorflow.keras.backend as K
 from tensorflow.keras.models import Sequential
@@ -198,7 +198,6 @@ class OnlineDL:
         self.model_path = "/tmp/%s_init" % model_name
         self.model_manager.download_model(self.model_path)
         self.model_uppath = "/tmp/%s" % model_name # will be "(model_name)_current"
-        self.model_upfilename = self.model_uppath.split('/')[-1]
 
         self.model_filename = self.model_path.split('/')[-1]
         self.online_method = online_method
@@ -255,12 +254,11 @@ class OnlineDL:
                 raise OnlineDLError
 
     def save(self):
-        # below parameter description
-        # self.model_uppath="/tmp/(model_name)_current"
-        # self.model_upfilename="(model_name)_current"
-        # self._loss=(float)value
         self.model.save(self.model_uppath, save_format='h5')
-        self.model_manager.upload_model(self.model_uppath, self.model_upfilename, loss=self._loss)
+        self.model_manager.upload_model(self.model_uppath, self.model_name, loss=self._loss)
+        post = {}
+        post['update_at_onlinedl'] = datetime.datetime.now()
+        self.collection.insert_one(post)
 
     @staticmethod
     def _check_attribute_error(target, arg_name):
@@ -280,15 +278,13 @@ class OnlineDL:
                 return target.weighted_matrics
 
     def _send_result(self, pred, true, id):
-        print('hi')
-        #TODO: send result to result-repo using mongodb
         for i in np.unique(id):
             post = {}
             post['amiid'] = i.item()
             post['pred'] = pred.reshape((pred.shape[0],))[np.where(id.reshape((id.shape[0],))==i)].tolist() # shape is (batch,)
             post['true'] = true.reshape((true.shape[0],))[np.where(id.reshape((id.shape[0],))==i)].tolist() # shape is (batch,)
             post['loss'] = self._loss.item()
-            post['timestamp'] = time.time() # time.time() is global UTC value
+            post['timestamp'] = datetime.datetime.now()
             self.collection.insert_one(post)
 
 

--- a/online-dl/onlinedl/onlinedl.py
+++ b/online-dl/onlinedl/onlinedl.py
@@ -240,9 +240,7 @@ class OnlineDL:
                 _wm = self._check_attribute_error(model, 'wm')
                 _tt = self._check_attribute_error(model, 'tt')
 
-                self.model = Sequential()
-                for layer in model.layers:
-                    self.model.add(layer)
+                self.model = model
 
                 self.opt_fn = model.optimizer
                 self.loss_fn = model.loss_functions[0]


### PR DESCRIPTION
update policy는 자주 업데이트하도록 약간 바꿨습니당

mongoDB는 datetime.datetime() 형식으로 바꾸고, onlinedl데이터베이스엔 "updated_at_onlinedl" 항목 추가. inference데이터베이스엔 "updated_at_inferencedl" 업데이트 시간 추가했어요.

그리고 onlinedl에서 re-run할때 생기는 버그는 keras.model 관련 버그라서 바꿨습니다.